### PR TITLE
[WIP] Add CLI to run the generators without having to add gem in the application directly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,23 @@
+PATH
+  remote: .
+  specs:
+    boring_generators (0.1.0)
+      thor
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.14.2)
+    rake (12.3.3)
+    thor (1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  boring_generators!
+  minitest (~> 5.0)
+  rake (~> 12.0)
+
+BUNDLED WITH
+   2.1.4

--- a/boring_generators.gemspec
+++ b/boring_generators.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "thor"
 end

--- a/exe/boring
+++ b/exe/boring
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('lib/boring_generators/cli', Dir.pwd)
+BoringGenerators::CLI.start

--- a/lib/boring_generators/cli.rb
+++ b/lib/boring_generators/cli.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "thor"
+require File.expand_path('lib/generators/boring/tailwind/install/install_generator', Dir.pwd)
+
+module BoringGenerators
+  class CLI < Thor
+    desc "tailwind:install", "Adds Tailwind CSS to the application"
+    def tailwind
+      Boring::Tailwind::InstallGenerator.invoke
+    end
+  end
+end


### PR DESCRIPTION
The aim of this PR is to allow users directly use generators without adding them in the application gem file. The cli would run something as follows: 
```
boring tailwind:install
```