### PR TITLE
Adds jquery boring generator installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* Adds JQuery install generator. ([@abhaynikam][])
 * Adds Bootstrap install generator. ([@abhaynikam][])
 
 ## 0.1.0 (September 5th, 2020)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Or install it yourself as:
 The boring generator introduces following generators:
 - Install Tailwind CSS: `rails generate boring:tailwind:install`
 - Install Bootstrap: `rails generate boring:bootstrap:install`
+- Install JQuery: `rails generate boring:jquery:install`
 
 ## Development
 

--- a/lib/generators/boring/jquery/install/install_generator.rb
+++ b/lib/generators/boring/jquery/install/install_generator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Boring
+  module Jquery
+    class InstallGenerator < Rails::Generators::Base
+      desc "Adds JQuery to the application"
+
+      def add_jquery_package
+        say "Adding JQuery packages", :green
+        run "yarn add jquery"
+      end
+
+      def add_jquery_plugin_provider_to_webpack_environment
+        say "Initailizing tailwind configuration", :green
+        if File.exist?("config/webpack/environment.js")
+          insert_into_file "config/webpack/environment.js", <<~RUBY, after: /@rails\/webpacker.*\n/
+            const webpack = require("webpack")
+
+            environment.plugins.append("Provide", new webpack.ProvidePlugin({
+              $: 'jquery',
+              jQuery: 'jquery'
+            }))
+          RUBY
+        else
+          say <<~WARNING, :red
+            ERROR: Looks like the webpacker installation is incomplete. Could not find environment.js in config/webpack.
+          WARNING
+        end
+      end
+    end
+  end
+end

--- a/test/generators/jquery_install_generator_test.rb
+++ b/test/generators/jquery_install_generator_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "generators/boring/jquery/install/install_generator"
+
+class JqueryInstallGeneratorTest < Rails::Generators::TestCase
+  tests Boring::Jquery::InstallGenerator
+  setup :build_app
+  teardown :teardown_app
+
+  include GeneratorHelper
+
+  def destination_root
+    app_path
+  end
+
+  def test_should_install_jquery_successfully
+    Dir.chdir(app_path) do
+      quietly { run_generator }
+
+      assert_file "package.json" do |content|
+        assert_match(/jquery/, content)
+      end
+
+      assert_file "config/webpack/environment.js" do |content|
+        expected = <<~RUBY
+          environment.plugins.append("Provide", new webpack.ProvidePlugin({
+            $: 'jquery',
+            jQuery: 'jquery'
+          }))
+        RUBY
+
+        assert_match(expected, content)
+      end
+    end
+  end
+
+  def test_should_warning_about_missing_webpacker_env_file
+    original_stdout = $stdout
+    $stdout = StringIO.new
+
+    Dir.chdir(app_path) do
+      FileUtils.rm_rf("#{app_path}/config/webpack/environment.js")
+      expected = "ERROR: Looks like the webpacker installation is incomplete. Could not find environment.js in config/webpack."
+      generator.add_jquery_plugin_provider_to_webpack_environment
+      $stdout.rewind
+      assert_match expected, $stdout.read
+    end
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
PR Fixes: 
- Adds jquery via NPM for rails.
- Adds the provider in the webpack environment. 

**Tested locally.**

NOTE: Need to figure out if two generator conflicts on adding same config. Example: bootstrap generator adds the jquery and also webpack environment. Need some cool regex match for this. Keeping in scope but not on priority.
