### PR TITLE
Add Pundit boring generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 * Adds favicon build generator. ([@abhaynikam][])
-* Adds Pundit install generator. ([@CiTroNaK][])
+* Adds Pundit install generator. ([@CiTroNaK][https://github.com/CiTroNaK])
 
 ## 0.4.0 (October 23rd, 2020)
 * Adds CircleCI install generator. ([@abhaynikam][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 * Adds favicon build generator. ([@abhaynikam][])
+* Adds Pundit install generator. ([@CiTroNaK][])
 
 ## 0.4.0 (October 23rd, 2020)
 * Adds CircleCI install generator. ([@abhaynikam][])

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The boring generator introduces following generators:
 - Install Travis CI: `rails generate boring:ci:travisci:install --ruby_version=<version>`
 - Install Rubocop: `rails generate boring:rubocop:install --ruby_version=<version>`
 - Build Favicon: `rails generate boring:favicon:build --application_name=<application_name> --favico_letter=<favico_letter> --primary_color=<color>`
+- Install Pundit: `rails generate boring:pundit:install`
 
 ## Development
 

--- a/lib/generators/boring/pundit/install/install_generator.rb
+++ b/lib/generators/boring/pundit/install/install_generator.rb
@@ -19,7 +19,7 @@ module Boring
         return if options[:skip_generator]
 
         say "Running Pundit Generator", :green
-        run "rails generate pundit:install"
+        run "DISABLE_SPRING=1 rails generate pundit:install"
       end
 
       def inject_pundit_to_controller

--- a/lib/generators/boring/pundit/install/install_generator.rb
+++ b/lib/generators/boring/pundit/install/install_generator.rb
@@ -41,7 +41,7 @@ module Boring
       def rescue_from_not_authorized
         return if options[:skip_rescue]
 
-        say "Add rescue from Pundit::NotAuthorizedError", :green
+        say "Adding rescue from Pundit::NotAuthorizedError", :green
 
         after = if File.read('app/controllers/application_controller.rb') =~ (/:verify_authorized/)
                   "after_action :verify_authorized\n"

--- a/lib/generators/boring/pundit/install/install_generator.rb
+++ b/lib/generators/boring/pundit/install/install_generator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'bundler'
+
+module Boring
+  module Pundit
+    class InstallGenerator < Rails::Generators::Base
+      desc "Adds pundit to the application"
+
+      def add_pundit_gem
+        say "Adding Pundit gem", :green
+
+        gem 'pundit'
+        Bundler.with_unbundled_env do
+          run "bundle install"
+        end
+      end
+
+      def run_pundit_generator
+        return if options[:skip_generator]
+
+        say "Running Pundit Generator", :green
+        run "rails generate pundit:install"
+      end
+
+      def inject_pundit_to_controller
+        say "Adding Pundit module into ApplicationController", :green
+        inject_into_file 'app/controllers/application_controller.rb', after: "class ApplicationController < ActionController::Base\n" do
+          "  include Pundit\n"
+        end
+      end
+
+      def ensure_policies
+        return if options[:skip_ensuring_policies]
+
+        say "Force ensuring policies", :green
+        inject_into_file 'app/controllers/application_controller.rb', after: "include Pundit\n" do
+          "  after_action :verify_authorized\n"
+        end
+      end
+
+      def rescue_from_not_authorized
+        return if options[:skip_rescue]
+
+        say "Add rescue from Pundit::NotAuthorizedError", :green
+
+        after = if File.read('app/controllers/application_controller.rb') =~ (/:verify_authorized/)
+                  "after_action :verify_authorized\n"
+                else
+                  "include Pundit\n"
+                end
+
+        inject_into_file 'app/controllers/application_controller.rb', after: after do
+          <<~RUBY
+            rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+            private
+
+            def user_not_authorized
+              flash[:alert] = "You are not authorized to perform this action."
+              redirect_to(request.referrer || root_path)
+            end
+          RUBY
+        end
+      end
+
+      def after_run
+        unless options[:skip_rescue]
+          say "\nPlease check the `application_controller.rb` file and fix any potential issues"
+        end
+
+        say "\nDon't forget, that you can generate policies with \nrails g pundit:policy Model\n"
+      end
+    end
+  end
+end

--- a/lib/generators/boring/pundit/install/install_generator.rb
+++ b/lib/generators/boring/pundit/install/install_generator.rb
@@ -7,6 +7,13 @@ module Boring
     class InstallGenerator < Rails::Generators::Base
       desc "Adds pundit to the application"
 
+      class_option :skip_ensuring_policies, type: :boolean, aliases: "-s",
+                   desc: "Skip before_action to ensure user is authorized"
+      class_option :skip_rescue, type: :boolean, aliases: "-sr",
+                   desc: "Skip adding rescue for Pundit::NotAuthorizedError"
+      class_option :skip_generator, type: :boolean, aliases: "-sg",
+                   desc: "Skip running Pundit install generator"
+
       def add_pundit_gem
         say "Adding Pundit gem", :green
 
@@ -51,14 +58,14 @@ module Boring
 
         inject_into_file 'app/controllers/application_controller.rb', after: after do
           <<~RUBY
-            rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+            \trescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-            private
+            \tprivate
 
-            def user_not_authorized
-              flash[:alert] = "You are not authorized to perform this action."
-              redirect_to(request.referrer || root_path)
-            end
+            \tdef user_not_authorized
+            \t  flash[:alert] = "You are not authorized to perform this action."
+            \t  redirect_to(request.referrer || root_path)
+            \tend
           RUBY
         end
       end

--- a/lib/generators/boring/pundit/install/install_generator.rb
+++ b/lib/generators/boring/pundit/install/install_generator.rb
@@ -10,9 +10,8 @@ module Boring
       def add_pundit_gem
         say "Adding Pundit gem", :green
 
-        gem 'pundit'
         Bundler.with_unbundled_env do
-          run "bundle install"
+          run "bundle add pundit"
         end
       end
 

--- a/test/generators/pundit_install_generator_test.rb
+++ b/test/generators/pundit_install_generator_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "generators/boring/pundit/install/install_generator"
+
+class PunditInstallGeneratorTest < Rails::Generators::TestCase
+  tests Boring::Pundit::InstallGenerator
+  setup :build_app
+  teardown :teardown_app
+
+  include GeneratorHelper
+
+  def destination_root
+    app_path
+  end
+
+  def test_should_install_pundit_successfully
+    Dir.chdir(app_path) do
+      quietly { run_generator }
+
+      assert_file "Gemfile" do |content|
+        assert_match(/pundit/, content)
+      end
+
+      assert_file "app/controllers/application_controller.rb" do |content|
+        assert_match(/include Pundit/, content)
+        assert_match(/:verify_authorized/, content)
+        assert_match(/rescue_from/, content)
+      end
+
+      assert_file "app/policies/application_policy.rb"
+    end
+  end
+
+  def test_should_skip_adding_ensuring_policies
+    Dir.chdir(app_path) do
+      quietly { run_generator [destination_root, "--skip_ensuring_policies"] }
+
+      assert_file "app/controllers/application_controller.rb" do |content|
+        assert_no_match(/verify_authorized/, content)
+      end
+    end
+  end
+
+  def test_should_skip_adding_rescue
+    Dir.chdir(app_path) do
+      quietly { run_generator [destination_root, "--skip_rescue"] }
+
+      assert_file "app/controllers/application_controller.rb" do |content|
+        assert_no_match(/rescue_from/, content)
+        assert_no_match(/user_not_authorized/, content)
+      end
+    end
+  end
+
+  def test_should_skip_runnig_pundit_generator
+    Dir.chdir(app_path) do
+      quietly { run_generator [destination_root, "--skip_generator"] }
+
+      assert_no_file "app/policies/application_policy.rb"
+    end
+  end
+end


### PR DESCRIPTION
First of all, I don't have any previous experience with Rails generators (this is also a reason, why I wanted to try it).

As you can see, I tried to proceed with the same, but I found a few issues.

1. I was forced to add `Bundler.with_unbundled_env` to be able to install the Pundit gem.
2. ~I use the same way to skip tasks, but it does not work (even in tests).~ fixed
3. I was forced to run the `rails generate pundit:install` before I include it in the `ApplicationController` (it would throw `uninitialized constant ApplicationController::Pundit`). ~I can see (overlooked) that it still does not work.~ fixed

I would be very glad if you can look at it and help me fix the tests.

I've manually tested it and it works.


```bash
➜ rails generate boring:pundit:install
Running via Spring preloader in process 21740
Adding Pundit gem
         run  bundle add pundit from "."
.
.
.
Running Pundit Generator
         run  DISABLE_SPRING=1 rails generate pundit:install from "."
      create  app/policies/application_policy.rb
Adding Pundit module into ApplicationController
      insert  app/controllers/application_controller.rb
Force ensuring policies
      insert  app/controllers/application_controller.rb
Add rescue from Pundit::NotAuthorizedError
      insert  app/controllers/application_controller.rb

Please check the `application_controller.rb` file and fix any potential issues

Don't forget, that you can generate policies with 
rails g pundit:policy Model


```

