### PR TITLE
Github Install Generator uses .ruby-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* Updates default ruby version of GitHub Actions install generator. ([@jamesglover][])
 
 ## 0.5.0 (December 20th, 2020)
 * Adds favicon build generator. ([@abhaynikam][])

--- a/lib/generators/boring/ci/github_action/install/install_generator.rb
+++ b/lib/generators/boring/ci/github_action/install/install_generator.rb
@@ -7,12 +7,16 @@ module Boring
         desc "Adds Github Action to the application"
         source_root File.expand_path("templates", __dir__)
 
-        DEFAULT_RUBY_VERSION = "2.7.1"
+        RUBY_VERSION_FILE = ".ruby-version"
+
+        DEFAULT_RUBY_VERSION = ".ruby-version"
         DEFAULT_NODE_VERSION = "10.13.0"
         DEFAULT_REPOSITORY_NAME = "boring_generators"
 
         class_option :ruby_version,     type: :string, aliases: "-v",
-                                                       desc: "Tell us the ruby version which you use for the application. Default to Ruby #{DEFAULT_RUBY_VERSION}"
+                                                       desc: "Tell us the ruby version which you use for the application. Default to Ruby #{DEFAULT_RUBY_VERSION},
+                                                       which will cause the action to use the version specified
+                                                       in the #{RUBY_VERSION_FILE} file."
         class_option :node_version,     type: :string, aliases: "-v",
                                                        desc: "Tell us the node version which you use for the application. Default to Node #{DEFAULT_NODE_VERSION}"
         class_option :repository_name,  type: :string, aliases: "-rn",
@@ -24,6 +28,18 @@ module Boring
           @repository_name = options[:repository_name] ? options[:repository_name] : DEFAULT_REPOSITORY_NAME
 
           template("ci.yml", ".github/workflows/ci.yml")
+
+          if @ruby_version == DEFAULT_RUBY_VERSION && !ruby_version_file_exists?
+            say <<~WARNING, :red
+              WARNING: The action was configured to use the ruby version sepecified in the .ruby-version
+              file, but no such file was present. Either create an appropriate .ruby-version file, or
+              update .github/workflows/ci.yml to use an explicit ruby version.
+            WARNING
+          end
+        end
+
+        def ruby_version_file_exists?
+          Pathname.new(destination_root).join(RUBY_VERSION_FILE).exist?
         end
       end
     end

--- a/lib/generators/boring/ci/github_action/install/install_generator.rb
+++ b/lib/generators/boring/ci/github_action/install/install_generator.rb
@@ -31,7 +31,7 @@ module Boring
 
           if @ruby_version == DEFAULT_RUBY_VERSION && !ruby_version_file_exists?
             say <<~WARNING, :red
-              WARNING: The action was configured to use the ruby version sepecified in the .ruby-version
+              WARNING: The action was configured to use the ruby version specified in the .ruby-version
               file, but no such file was present. Either create an appropriate .ruby-version file, or
               update .github/workflows/ci.yml to use an explicit ruby version.
             WARNING

--- a/test/generators/ci/github_action_install_generator_test.rb
+++ b/test/generators/ci/github_action_install_generator_test.rb
@@ -20,7 +20,7 @@ class GithubActionInstallGeneratorTest < Rails::Generators::TestCase
 
       assert_file ".github/workflows/ci.yml" do |content|
         assert_match("boring_generators_test", content)
-        assert_match("2.7.1", content)
+        assert_match(".ruby-version", content)
         assert_match("10.13.0", content)
       end
     end
@@ -55,6 +55,32 @@ class GithubActionInstallGeneratorTest < Rails::Generators::TestCase
         assert_match("boring_generators_test", content)
         assert_match("10.13.2", content)
       end
+    end
+  end
+
+  def test_generator_should_warn_if_ruby_version_file_is_specified_but_missing
+    Dir.chdir(app_path) do
+      File.delete('.ruby-version')
+      output = run_generator [destination_root, "--ruby_version=.ruby-version"]
+      expected = "WARNING: The action was configured to use the ruby version sepecified in the .ruby-version"
+      assert_match  expected, output
+    end
+  end
+
+  def test_generator_should_not_warn_if_ruby_version_file_is_specified_and_present
+    Dir.chdir(app_path) do
+      output = run_generator [destination_root, "--ruby_version=.ruby-version"]
+      expected = "WARNING: The action was configured to use the ruby version sepecified in the .ruby-version"
+      refute_match  expected, output
+    end
+  end
+
+  def test_generator_should_not_warn_if_a_specifi_ruby_version_is_specified
+    Dir.chdir(app_path) do
+      File.delete('.ruby-version')
+      output = run_generator [destination_root, "--ruby_version=2.7.1"]
+      expected = "WARNING: The action was configured to use the ruby version sepecified in the .ruby-version"
+      refute_match  expected, output
     end
   end
 end


### PR DESCRIPTION
The ruby/setup-ruby@v1 action will default to using
the .ruby-version file, if no explicit ruby version is specified.
This behaviour can also be invoked by explicitly specifying
'.ruby-version'.

See https://github.com/ruby/setup-ruby/commit/a61be15bffe8c2671699ce4b4eb6e7c8f2ce3f4d

This change updates the generator to use this by default,
resulting in a single source-of-truth for the project ruby version.
If the ruby-version file is missing, it will display a warning to
the user.

## Further thoughts
This follows on from some of my comments made over on Reddit. I hope my comments there didn't come across as overly negative. Your doing great work, and tooling like boring_generators is great for getting things set up quickly. Thank you.

- In contrast to my initial comments on Reddit, I instead opted to explicitly specify '.ruby-version' as the ruby version. This has the advantage of keeping the template simple and unchanged, but also makes the whole thing far more explicit.

- When implementing this I was a little indecisive about how to handle situations in which the user did not have a .ruby-version file. I considered the following:

1) Keep things simple, and don't even bother checking.
2) Detect the situation and produce a warning
3) Detect the situation and produce an error, requiring an explicit version be specified
4) Have a default value of 2.7.1 if no .ruby-version file was present, and .ruby-version otherwise
5) Create the .ruby-version as part of the template.

I opted for option 2, feeling it stuck a balance between being easy to use, without introducing unexpected changes, or difficult to predict behaviours. I'm more than happy to make changes to follow one of the other options if you'd prefer.

I'll also be popping in a pull request with the bundle installation changes separately, partly as I'm not 100% they are an improvement.