### PR TITLE
Simplify the Github actions install template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* Simplify generated GitHub Actions install ([@jamesglover][])
 
 ## 0.5.0 (December 20th, 2020)
 * Adds favicon build generator. ([@abhaynikam][])

--- a/lib/generators/boring/ci/github_action/install/templates/ci.yml.tt
+++ b/lib/generators/boring/ci/github_action/install/templates/ci.yml.tt
@@ -20,17 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: <%= @ruby_version %>
-      - name: Ruby gem cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Setup Node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
ruby/setup-ruby@v1 provide the ability to automatically
install and cache gems by setting the parameter
bundler-cache to true. This avoids the need to perform
those two steps ourselves.

*Additional thoughts*
One disadvantage of this approach is that it is less explicit, and doesn't provide any pointer as to how a user may introduce more advanced setups if necessary. (Such as using 'bundle config without xxx'). In contrast, the existing approach guides users in this direction, and also ensures they don't accidentally nuke their caching in the process.