### PR TITLE
Fix GitHub ci generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Adds Stimulus generator. ([@abhaynikam][])
 * Adds Rails Admin generator. ([@abhaynikam][])
 * Adds Paper Trail generator. ([@abhaynikam][])
+* Update default node-version for GitHub Action generator and fixes PG setup issues. ([@abhaynikam][])
 
 ## 0.10.0 (May 26th, 2021)
 * Updates Stripe payment generator. ([@abhaynikam][])

--- a/lib/generators/boring/ci/github_action/install/install_generator.rb
+++ b/lib/generators/boring/ci/github_action/install/install_generator.rb
@@ -10,7 +10,7 @@ module Boring
         RUBY_VERSION_FILE = ".ruby-version"
 
         DEFAULT_RUBY_VERSION = ".ruby-version"
-        DEFAULT_NODE_VERSION = "10.13.0"
+        DEFAULT_NODE_VERSION = "14"
         DEFAULT_REPOSITORY_NAME = "boring_generators"
 
         class_option :ruby_version,     type: :string, aliases: "-v",

--- a/lib/generators/boring/ci/github_action/install/templates/ci.yml.tt
+++ b/lib/generators/boring/ci/github_action/install/templates/ci.yml.tt
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   test:
     name: Tests
@@ -10,8 +14,9 @@ jobs:
         env:
           POSTGRES_USER: <%= @repository_name %>
           POSTGRES_DB: <%= "#{@repository_name}_test" %>
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: postgres
         ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Checkout code
@@ -25,6 +30,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: <%= @node_version %>
+      - name: Install library for postgres
+        run: sudo apt-get install libpq-dev
       - name: Find yarn cache location
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -43,7 +50,13 @@ jobs:
           RAILS_ENV: test
           PGHOST: localhost
           PGUSER: <%= @repository_name %>
+          PGPASSWORD: postgres
         run: |
           bin/rails db:setup
       - name: Run tests
+        env:
+          RAILS_ENV: test
+          PGHOST: localhost
+          PGUSER: <%= @repository_name %>
+          PGPASSWORD: postgres
         run: bundle exec rails test # TODO: Update the test runner command as per your requirement.

--- a/test/generators/ci/github_action_install_generator_test.rb
+++ b/test/generators/ci/github_action_install_generator_test.rb
@@ -21,7 +21,7 @@ class GithubActionInstallGeneratorTest < Rails::Generators::TestCase
       assert_file ".github/workflows/ci.yml" do |content|
         assert_match("boring_generators_test", content)
         assert_match(".ruby-version", content)
-        assert_match("10.13.0", content)
+        assert_match("14", content)
       end
     end
   end


### PR DESCRIPTION
- Updates the default node-version setup in GitHub actions CI.
- Fixes the issues in PG setup failing for the generator generated YAML. 