### PR TITLE
Added a line to config/initializers/devise.rb to accept turbo

### DIFF
--- a/lib/generators/boring/devise/install/install_generator.rb
+++ b/lib/generators/boring/devise/install/install_generator.rb
@@ -65,8 +65,9 @@ module Boring
         end
         def add_turbo_stream
           insert_into_file "config/initializers/devise.rb", <<~RUBY, after: /Devise.setup do |config|/
-          \n
-          \tconfig.navigational_formats = ['*/*', :html, :turbo_stream]
+            \n
+            \tconfig.navigational_formats = ['*/*', :html, :turbo_stream]
+         RUBY
         end
       end
     end

--- a/lib/generators/boring/devise/install/install_generator.rb
+++ b/lib/generators/boring/devise/install/install_generator.rb
@@ -15,6 +15,7 @@ module Boring
                    desc: "Skip generating devise model"
 
       def add_devise_gem
+        puts "hello world"
         say "Adding devise gem", :green
         Bundler.with_unbundled_env do
           run "bundle add devise"

--- a/lib/generators/boring/devise/install/install_generator.rb
+++ b/lib/generators/boring/devise/install/install_generator.rb
@@ -64,7 +64,7 @@ module Boring
           run "DISABLE_SPRING=1 bundle exec rails generate devise:views #{model_name.pluralize}"
         end
         def add_turbo_stream
-          insert_into_file "config/initializers/devise.rb", <<~RUBY, after: /Devise.setup do |config|/
+          insert_into_file "config/initializers/devise.rb", <<~RUBY, after: /config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'/
             \n
             \tconfig.navigational_formats = ['*/*', :html, :turbo_stream]
          RUBY

--- a/lib/generators/boring/devise/install/install_generator.rb
+++ b/lib/generators/boring/devise/install/install_generator.rb
@@ -63,12 +63,12 @@ module Boring
         Bundler.with_unbundled_env do
           run "DISABLE_SPRING=1 bundle exec rails generate devise:views #{model_name.pluralize}"
         end
-        def add_turbo_stream
-          insert_into_file "config/initializers/devise.rb", <<~RUBY, after: /config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'/
-            \n
-            \tconfig.navigational_formats = ['*/*', :html, :turbo_stream]
-         RUBY
-        end
+      end
+      def add_turbo_stream
+        insert_into_file "config/initializers/devise.rb", <<~RUBY, after: /config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'/
+          \n
+          \tconfig.navigational_formats = ['*/*', :html, :turbo_stream]
+       RUBY
       end
     end
   end

--- a/lib/generators/boring/devise/install/install_generator.rb
+++ b/lib/generators/boring/devise/install/install_generator.rb
@@ -15,7 +15,6 @@ module Boring
                    desc: "Skip generating devise model"
 
       def add_devise_gem
-        puts "hello world"
         say "Adding devise gem", :green
         Bundler.with_unbundled_env do
           run "bundle add devise"
@@ -63,6 +62,11 @@ module Boring
 
         Bundler.with_unbundled_env do
           run "DISABLE_SPRING=1 bundle exec rails generate devise:views #{model_name.pluralize}"
+        end
+        def add_turbo_stream
+          insert_into_file "config/initializers/devise.rb", <<~RUBY, after: /Devise.setup do |config|/
+          \n
+          \tconfig.navigational_formats = ['*/*', :html, :turbo_stream]
         end
       end
     end


### PR DESCRIPTION
Now when a new user is signed up they are redirected to the page they came from, instead of getting an error.  And I tested it and it added the config.navigational_formats = ['*/*', :html, :turbo_stream] line to config/initializers/devise.rb