### PR TITLE
Generator for letter opener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* Adds Letter Opener generator. ([@coolprobn][])
 
 ## 0.12.0 (May 8th, 2023)
 * Adds Flipper generator. ([@abhaynikam][])
@@ -11,7 +12,6 @@
 * Updates Bootstrap generator for supporting Bootstrap 5 with popper.js. ([@abhaynikam][])
 * Adds Overcommit generator for RuboCop. ([@coolprobn][])
 * Updates RuboCop generator to add rubocop-rake extension and support test frameworks ([@coolprobn][])
-* Adds Letter Opener generator. ([@coolprobn][])
 
 ## 0.11.0 (June 23rd, 2021)
 * Adds Stimulus generator. ([@abhaynikam][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update default node-version for GitHub Action generator and fixes PG setup issues. ([@abhaynikam][])
 * Updates Bootstrap generator for supporting Bootstrap 5 with popper.js. ([@abhaynikam][])
 * Adds Overcommit generator for RuboCop. ([@coolprobn][])
+* Adds Letter Opener generator. ([@coolprobn][])
 
 ## 0.11.0 (June 23rd, 2021)
 * Adds Stimulus generator. ([@abhaynikam][])

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    boring_generators (0.11.0)
+    boring_generators (0.12.0)
       railties
 
 GEM
@@ -143,4 +143,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.3.12
+   2.4.10

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The boring generator introduces following generators:
 - Install FactoryBot: `rails generate boring:factory_bot:install`
 - Install Faker: `rails generate boring:faker:install`
 - Install Overcommit with RuboCop: `rails generate boring:overcommit:pre_commit:rubocop:install`
+- Install Letter Opener: `rails generate boring:letter_opener:install`
 
 ## Screencasts
 

--- a/lib/generators/boring/letter_opener/install/install_generator.rb
+++ b/lib/generators/boring/letter_opener/install/install_generator.rb
@@ -3,7 +3,7 @@
 module Boring
   module LetterOpener
     class InstallGenerator < Rails::Generators::Base
-      desc "Adds Letter Opener gem to the application for previewing email in the default browser instead of sending it"
+      desc "Adds letter_opener gem for previewing email in development environment"
 
       def add_letter_opener_gem
         say "Adding letter_opener gem", :green
@@ -24,14 +24,15 @@ module Boring
         say "Configuring letter_opener", :green
 
         configuration_content = <<~RUBY.chomp
-          \n
+          \n\t# Preview email in the browser instead of sending it
           \tconfig.action_mailer.delivery_method = :letter_opener
           \tconfig.action_mailer.perform_deliveries = true
+          end
         RUBY
 
-        insert_into_file "config/environments/development.rb",
-                         configuration_content,
-                         after: /config.action_mailer.perform_caching = (true|false)/
+        gsub_file "config/environments/development.rb",
+                  /end\Z/,
+                  configuration_content
       end
     end
   end

--- a/lib/generators/boring/letter_opener/install/install_generator.rb
+++ b/lib/generators/boring/letter_opener/install/install_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Boring
+  module LetterOpener
+    class InstallGenerator < Rails::Generators::Base
+      desc "Adds Letter Opener to the application for previewing email in the default browser instead of sending it"
+
+      def add_letter_opener_gem
+        say "Adding letter_opener gem", :green
+
+        gem_content = <<~RUBY
+          \t# Preview email in the default browser instead of sending it to real mailbox
+          \tgem "letter_opener"
+        RUBY
+
+        insert_into_file "Gemfile", gem_content, after: /group :development do/
+
+        Bundler.with_unbundled_env do
+          run "bundle install"
+        end
+      end
+
+      def configure_letter_opener
+        say "Configuring letter_opener", :green
+
+        configuration_content = <<~RUBY.chomp
+          \n
+          \tconfig.action_mailer.delivery_method = :letter_opener
+          \tconfig.action_mailer.perform_deliveries = true
+        RUBY
+
+        insert_into_file "config/environments/development.rb",
+                         configuration_content,
+                         after: /config.action_mailer.perform_caching = (true|false)/
+      end
+    end
+  end
+end

--- a/lib/generators/boring/letter_opener/install/install_generator.rb
+++ b/lib/generators/boring/letter_opener/install/install_generator.rb
@@ -3,7 +3,7 @@
 module Boring
   module LetterOpener
     class InstallGenerator < Rails::Generators::Base
-      desc "Adds Letter Opener to the application for previewing email in the default browser instead of sending it"
+      desc "Adds Letter Opener gem to the application for previewing email in the default browser instead of sending it"
 
       def add_letter_opener_gem
         say "Adding letter_opener gem", :green

--- a/test/generators/letter_opener_install_generator_test.rb
+++ b/test/generators/letter_opener_install_generator_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "generators/boring/letter_opener/install/install_generator"
+
+class AuditInstallGeneratorTest < Rails::Generators::TestCase
+  tests Boring::LetterOpener::InstallGenerator
+  setup :build_app
+  teardown :teardown_app
+
+  include GeneratorHelper
+
+  def destination_root
+    app_path
+  end
+
+  def test_should_install_letter_opener_gem
+    Dir.chdir(app_path) do
+      quietly { generator.add_letter_opener_gem }
+
+      assert_file "Gemfile" do |content|
+        assert_match(/letter_opener/, content)
+      end
+    end
+  end
+
+  def test_should_add_gem_configurations
+    Dir.chdir(app_path) do
+      quietly { generator.configure_letter_opener }
+
+      assert_file "config/environments/development.rb" do |content|
+        assert_match(/config.action_mailer.delivery_method = :letter_opener/, content)
+        assert_match(/config.action_mailer.perform_deliveries = true/, content)
+      end
+    end
+  end
+end

--- a/test/generators/letter_opener_install_generator_test.rb
+++ b/test/generators/letter_opener_install_generator_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "generators/boring/letter_opener/install/install_generator"
 
-class AuditInstallGeneratorTest < Rails::Generators::TestCase
+class LetterOpenerInstallGeneratorTest < Rails::Generators::TestCase
   tests Boring::LetterOpener::InstallGenerator
   setup :build_app
   teardown :teardown_app
@@ -26,7 +26,7 @@ class AuditInstallGeneratorTest < Rails::Generators::TestCase
 
   def test_should_add_gem_configurations
     Dir.chdir(app_path) do
-      quietly { generator.configure_letter_opener }
+      quietly { run_generator }
 
       assert_file "config/environments/development.rb" do |content|
         assert_match(/config.action_mailer.delivery_method = :letter_opener/, content)


### PR DESCRIPTION
This PR adds generator to install and configure letter opener gem which is used to preview email in the browser instead of sending it to real mailbox for development environment.

**Note**:
I closed the previous PR because update from my forked branch was not being updated possibly due to some syncing issue in Github.

I have resolved all comments in the other PR here.

Old PR: https://github.com/abhaynikam/boring_generators/pull/82

