### PR TITLE
Fix the letter opener generator indentation issue

### DIFF
--- a/lib/generators/boring/letter_opener/install/install_generator.rb
+++ b/lib/generators/boring/letter_opener/install/install_generator.rb
@@ -8,9 +8,9 @@ module Boring
       def add_letter_opener_gem
         say "Adding letter_opener gem", :green
 
-        gem_content = <<~RUBY
-          \t# Preview email in the default browser instead of sending it to real mailbox
-          \tgem "letter_opener"
+        gem_content = <<~RUBY.indent(2)
+          \n# Preview email in the default browser instead of sending it to real mailbox
+          gem "letter_opener"
         RUBY
 
         insert_into_file "Gemfile", gem_content, after: /group :development do/
@@ -23,16 +23,15 @@ module Boring
       def configure_letter_opener
         say "Configuring letter_opener", :green
 
-        configuration_content = <<~RUBY.chomp
-          \n\t# Preview email in the browser instead of sending it
-          \tconfig.action_mailer.delivery_method = :letter_opener
-          \tconfig.action_mailer.perform_deliveries = true
-          end
+        configuration_content = <<~RUBY.chomp.indent(2)
+          \n# Preview email in the browser instead of sending it
+          config.action_mailer.delivery_method = :letter_opener
+          config.action_mailer.perform_deliveries = true
         RUBY
 
         gsub_file "config/environments/development.rb",
                   /end\Z/,
-                  configuration_content
+                  "#{configuration_content}\nend"
       end
     end
   end


### PR DESCRIPTION
Background
---

Letter opener generator is adding the gem under the development gem group but without the new line due to which when another gem needs to be added to the same group, it's not working. For e.g.  when adding letter opener and rack mini profiler subsequently.

Fix
---

I have added new line and also proper indentation so content looks good inside the file they are added to without throwing error on subsequent generators for the same gem group.