### PR TITLE
Fix name mismatch between omniauth strategy and callback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Adds Gitlab CI generator. ([@coolprobn][])
+* Fixed callback method name for Google OAuth2 Omniauth ([@coezbek][])
 
 ## 0.14.0 (Aug 4th, 2024)
 

--- a/lib/generators/boring/oauth/google/install/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/boring/oauth/google/install/templates/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
   skip_before_action :verify_authenticity_token, only: :google_auth
 
-  def google_auth2
+  def google_oauth2
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])
 

--- a/lib/generators/boring/oauth/google/install/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/boring/oauth/google/install/templates/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
   skip_before_action :verify_authenticity_token, only: :google_auth
 
-  def google_auth
+  def google_auth2
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])
 


### PR DESCRIPTION
Omniauth google didn't work out of the box, because callback method was misnamed.
