### PR TITLE
Fix name mismatch between omniauth strategy and callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-* Update Tailwind generator to use tailwindcss-rails gem instead of manually installing everything via npm
+* Update Tailwind generator to use tailwindcss-rails gem instead of manually installing everything via npm ([@coolprobn][])
+* Fixed callback method name for Google OAuth2 Omniauth ([@coezbek][] & [@coolprobn][])
 
 ## 0.15.0 (Oct 22nd, 2024)
 
@@ -120,3 +121,4 @@
 [@aadil]: https://github.com/AdilRT
 [@mausamp]: https://github.com/mausamp
 [@TheZero0-ctrl]: https://github.com/TheZero0-ctrl
+[@coezbek]: https://github.com/coezbek

--- a/lib/generators/boring/oauth/base_generator.rb
+++ b/lib/generators/boring/oauth/base_generator.rb
@@ -5,6 +5,10 @@ require 'bundler'
 module Boring
   module Oauth
     module BaseGenerator
+      def add_omniauth_rails_csrf_protection_gem
+        check_and_install_gem("omniauth-rails_csrf_protection")
+      end
+      
       def add_provider_and_uuid_user_details
         say "Adding migration to add provider and uuid columns to users", :green
         Bundler.with_unbundled_env do

--- a/lib/generators/boring/oauth/base_generator.rb
+++ b/lib/generators/boring/oauth/base_generator.rb
@@ -5,6 +5,8 @@ require 'bundler'
 module Boring
   module Oauth
     module BaseGenerator
+      class MissingDeviseConfigurationError < StandardError; end
+
       def add_omniauth_rails_csrf_protection_gem
         check_and_install_gem("omniauth-rails_csrf_protection")
       end

--- a/lib/generators/boring/oauth/facebook/install/install_generator.rb
+++ b/lib/generators/boring/oauth/facebook/install/install_generator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'bundler'
+require 'boring_generators/generator_helper'
 require 'generators/boring/oauth/base_generator'
 
 module Boring
   module Oauth
     module Facebook
       class InstallGenerator < Rails::Generators::Base
+        include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
         class MissingDeviseConfigurationError < StandardError; end
@@ -22,6 +24,7 @@ module Boring
         end
 
         def invoke_common_generator_methods
+          add_omniauth_rails_csrf_protection_gem
           @oauth_name = :facebook
           add_provider_and_uuid_user_details
           configure_devise_omniauth

--- a/lib/generators/boring/oauth/facebook/install/install_generator.rb
+++ b/lib/generators/boring/oauth/facebook/install/install_generator.rb
@@ -11,8 +11,6 @@ module Boring
         include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
-        class MissingDeviseConfigurationError < StandardError; end
-
         desc "Adds facebook OmniAuth to the application"
         source_root File.expand_path("templates", __dir__)
 

--- a/lib/generators/boring/oauth/facebook/install/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/boring/oauth/facebook/install/templates/omniauth_callbacks_controller.rb
@@ -1,7 +1,4 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
-  skip_before_action :verify_authenticity_token, only: :facebook
-
   def facebook
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])

--- a/lib/generators/boring/oauth/github/install/install_generator.rb
+++ b/lib/generators/boring/oauth/github/install/install_generator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'bundler'
+require 'boring_generators/generator_helper'
 require 'generators/boring/oauth/base_generator'
 
 module Boring
   module Oauth
     module Github
       class InstallGenerator < Rails::Generators::Base
+        include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
         class MissingDeviseConfigurationError < StandardError; end
@@ -22,6 +24,7 @@ module Boring
         end
 
         def invoke_common_generator_methods
+          add_omniauth_rails_csrf_protection_gem
           @oauth_name = :github
           add_provider_and_uuid_user_details
           configure_devise_omniauth

--- a/lib/generators/boring/oauth/github/install/install_generator.rb
+++ b/lib/generators/boring/oauth/github/install/install_generator.rb
@@ -11,8 +11,6 @@ module Boring
         include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
-        class MissingDeviseConfigurationError < StandardError; end
-
         desc "Adds GitHub OmniAuth to the application"
         source_root File.expand_path("templates", __dir__)
 

--- a/lib/generators/boring/oauth/github/install/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/boring/oauth/github/install/templates/omniauth_callbacks_controller.rb
@@ -1,7 +1,4 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
-  skip_before_action :verify_authenticity_token, only: :github
-
   def github
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])

--- a/lib/generators/boring/oauth/google/install/install_generator.rb
+++ b/lib/generators/boring/oauth/google/install/install_generator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'bundler'
+require 'boring_generators/generator_helper'
 require 'generators/boring/oauth/base_generator'
 
 module Boring
   module Oauth
     module Google
       class InstallGenerator < Rails::Generators::Base
+        include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
         class MissingDeviseConfigurationError < StandardError; end
@@ -22,6 +24,7 @@ module Boring
         end
 
         def invoke_common_generator_methods
+          add_omniauth_rails_csrf_protection_gem
           @oauth_name = :google_oauth2
           add_provider_and_uuid_user_details
           configure_devise_omniauth

--- a/lib/generators/boring/oauth/google/install/install_generator.rb
+++ b/lib/generators/boring/oauth/google/install/install_generator.rb
@@ -11,8 +11,6 @@ module Boring
         include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
-        class MissingDeviseConfigurationError < StandardError; end
-
         desc "Adds Google OmniAuth to the application"
         source_root File.expand_path("templates", __dir__)
 

--- a/lib/generators/boring/oauth/google/install/templates/README
+++ b/lib/generators/boring/oauth/google/install/templates/README
@@ -15,9 +15,10 @@ Some setup you must do manually if you haven't yet:
      after registering the Rails application on: https://code.google.com/apis/console/
      For example:
 
-     config.omniauth :google_auth, "APP_ID", "APP_SECRET"
+     config.omniauth :google_oauth2, "APP_ID", "APP_SECRET"
 
   3. Your omniauth callback URL will be: `<host>/users/auth/google_oauth2/callback`. Please update
      callback URL in Google after registering your omniauth application.
+     e.g. https://boringgenerators.com/users/auth/google_oauth2/callback
 
 ===============================================================================

--- a/lib/generators/boring/oauth/google/install/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/boring/oauth/google/install/templates/omniauth_callbacks_controller.rb
@@ -1,21 +1,14 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
-  skip_before_action :verify_authenticity_token, only: :google_auth
-
-  def google_auth
+  def google_oauth2
     # You need to implement the method below in your model (e.g. app/models/user.rb)
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+    @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
-      set_flash_message(:notice, :success, kind: "Google") if is_navigational_format?
+      flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Google'
+      sign_in_and_redirect @user, event: :authentication
     else
-      session["devise.google_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores
-      redirect_to new_user_registration_url
+      session['devise.google_data'] = request.env['omniauth.auth'].except('extra') # Removing extra as it can overflow some session stores
+      redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
     end
-  end
-
-  def failure
-    redirect_to root_path
   end
 end

--- a/lib/generators/boring/oauth/twitter/install/install_generator.rb
+++ b/lib/generators/boring/oauth/twitter/install/install_generator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'bundler'
+require 'boring_generators/generator_helper'
 require 'generators/boring/oauth/base_generator'
 
 module Boring
   module Oauth
     module Twitter
       class InstallGenerator < Rails::Generators::Base
+        include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
         class MissingDeviseConfigurationError < StandardError; end
@@ -22,6 +24,7 @@ module Boring
         end
 
         def invoke_common_generator_methods
+          add_omniauth_rails_csrf_protection_gem
           @oauth_name = :twitter
           add_provider_and_uuid_user_details
           configure_devise_omniauth

--- a/lib/generators/boring/oauth/twitter/install/install_generator.rb
+++ b/lib/generators/boring/oauth/twitter/install/install_generator.rb
@@ -11,8 +11,6 @@ module Boring
         include BoringGenerators::GeneratorHelper
         include Boring::Oauth::BaseGenerator
 
-        class MissingDeviseConfigurationError < StandardError; end
-
         desc "Adds Twitter OmniAuth to the application"
         source_root File.expand_path("templates", __dir__)
 

--- a/lib/generators/boring/oauth/twitter/install/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/boring/oauth/twitter/install/templates/omniauth_callbacks_controller.rb
@@ -1,7 +1,4 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
-  skip_before_action :verify_authenticity_token, only: :twitter
-
   def twitter
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])

--- a/test/generators/oauth/google_install_generator_test.rb
+++ b/test/generators/oauth/google_install_generator_test.rb
@@ -22,6 +22,7 @@ class OauthGoogleInstallGeneratorTest < Rails::Generators::TestCase
       quietly { run_generator }
 
       assert_gem "omniauth-google-oauth2"
+      assert_gem "omniauth-rails_csrf_protection"
       assert_migration "db/migrate/add_omniauth_to_users.rb"
       assert_file "config/initializers/devise.rb" do |content|
         assert_match('config.omniauth :google_oauth2', content)


### PR DESCRIPTION
I have wrapped up the the fix for the issue by continuing on the work done by [@coezbek](https://github.com/coezbek) in the PR https://github.com/abhaynikam/boring_generators/pull/123 

Also closes #32 

Tasks
---

- Change method name from google_auth to google_oauth2
- Add omniauth-rails_csrf_protection gem for csrf protection and remove skip csrf check from all oauth controller templates
